### PR TITLE
Fix infinite loop in CR calculate when legendary action cost is 0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "5e-monster-maker",
-  "version": "2.2.10",
+  "version": "2.2.11",
   "description": "A monster builder and generator for 5th Edition Dungeons and Dragons. Effortlessly create a monster with tools for automatically computing CR, formatting a statblock, and managing your monster actions and traits.",
   "productName": "Falindrith's D&D Monster Maker",
   "author": "Evan Shimizu <ebshimizu@gmail.com>",

--- a/src/components/ChangelogContent.vue
+++ b/src/components/ChangelogContent.vue
@@ -1,6 +1,22 @@
 <template>
   <q-timeline color="secondary">
     <q-timeline-entry
+      title="v2.2.11"
+      subtitle="Bugfix - 12/19/2024"
+      icon="build"
+      color="primary"
+    >
+      <div class="text-body2">
+        <ul>
+          <li>
+            <github-issue-link :issue="138" /> Fixed infinite loop in CR
+            calculation when legendary action cost was 0. The UI should also now
+            prevent you from setting a cost of 0.
+          </li>
+        </ul>
+      </div>
+    </q-timeline-entry>
+    <q-timeline-entry
       title="v2.2.10"
       subtitle="Bugfix - 11/26/2024"
       icon="build"

--- a/src/components/cr/useCr.ts
+++ b/src/components/cr/useCr.ts
@@ -74,8 +74,11 @@ export const useCr = () => {
 
       // first, figure out if we have multi-cost items
       for (const action of currentActions) {
-        if (action.cost >= highestCost) {
-          highestCost = action.cost
+        // address issues with 0 cost actions
+        const safeCost = Math.max(1, action.cost)
+
+        if (safeCost >= highestCost) {
+          highestCost = safeCost
           if (action.damage > highestCostDamage) {
             highestCostDamage = action.damage
           }
@@ -85,10 +88,13 @@ export const useCr = () => {
       // now that we know the highest remaining cost and the damage that's expected, check to see
       // if any lower cost items can match that damage
       const adjustedDamageActions = currentActions.map((a) => {
+        const safeCost = Math.max(a.cost, 1)
+
         return {
-          adjustedDamage: a.damage * Math.floor(highestCost / a.cost),
-          addCount: Math.floor(highestCost / a.cost),
+          adjustedDamage: a.damage * Math.floor(highestCost / safeCost),
+          addCount: Math.floor(highestCost / safeCost),
           ...a,
+          cost: safeCost,
         }
       })
 

--- a/src/components/editor/LegendaryActionsEditor.vue
+++ b/src/components/editor/LegendaryActionsEditor.vue
@@ -109,7 +109,7 @@
             <q-input
               :model-value="la.cost"
               type="number"
-              min="0"
+              min="1"
               :label="$t('editor.legendary.cost')"
               @update:model-value="
                 (value: string | number | null) => (la.cost = validateNumber(value, 1))

--- a/src/components/editor/MythicActionsEditor.vue
+++ b/src/components/editor/MythicActionsEditor.vue
@@ -86,7 +86,7 @@
             <q-input
               :model-value="la.cost"
               type="number"
-              min="0"
+              min="1"
               :label="$t('editor.legendary.cost')"
               @update:model-value="
                 (value: string | number | null) => (la.cost = validateNumber(value, 1))


### PR DESCRIPTION
also retroactively fixes this for monsters that had a 0 cost LA/MA set. 