### PR TITLE
Add quasar/cli to dev dependencies, force clean install

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ There could be a couple reasons for this. Before filing and issue with the core 
 
 This project is written in Vue with Quasar and uses npm as its package manager. I'm pretty sure it'd work with yarn as well.
 
-Clone the repository and install the [Quasar cli](https://quasar.dev/start/quasar-cli) with `npm install --location=global @quasar/cli`. After that, run `npm install`. The development server can then be started with `quasar dev`.
+Clone the repository and install the [Quasar cli](https://quasar.dev/start/quasar-cli) with `npm install @quasar/cli  --save-dev`. After that, run `npm clean-install`. The development server can then be started with `quasar dev`.
 
 ### Translations
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ There could be a couple reasons for this. Before filing and issue with the core 
 
 This project is written in Vue with Quasar and uses npm as its package manager. I'm pretty sure it'd work with yarn as well.
 
-Clone the repository and install the [Quasar cli](https://quasar.dev/start/quasar-cli) with `npm install @quasar/cli  --save-dev`. After that, run `npm clean-install`. The development server can then be started with `quasar dev`.
+Clone the repository and run `npm install`. The development server can then be started with `quasar dev`.
 
 ### Translations
 

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "@vueuse/core": "^8.6.0",
     "copy-to-clipboard": "^3.3.2",
     "core-js": "^3.6.5",
-    "fs-extra": "^10.1.0",
     "dom-to-image-more": "^3.5.0",
+    "fs-extra": "^10.1.0",
     "json-url": "^3.0.0",
     "jsonschema": "^1.4.1",
     "lodash": "^4.17.21",
@@ -34,6 +34,7 @@
   "devDependencies": {
     "@intlify/vite-plugin-vue-i18n": "^3.3.1",
     "@quasar/app-vite": "^1.9.5",
+    "@quasar/cli": "^2.4.1",
     "@types/dom-to-image": "^2.6.4",
     "@types/lodash": "^4.14.182",
     "@types/node": "^12.20.21",


### PR DESCRIPTION
When adding quasar/cli after having run `npm install`, it might not download the correct esbuild architecture. This PR instructs to add quasar/cli to dev dependencies (cleaner?) and to force a clean install of the project afterwards.

I encountered this problem on a Mac M1, so maybe Windows/Linux machines don't show this behaviour.