### PR TITLE
prepend open5e calls with v1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "5e-monster-maker",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "description": "A monster builder and generator for 5th Edition Dungeons and Dragons. Effortlessly create a monster with tools for automatically computing CR, formatting a statblock, and managing your monster actions and traits.",
   "productName": "Falindrith's D&D Monster Maker",
   "author": "Evan Shimizu <ebshimizu@gmail.com>",

--- a/src/components/ChangelogContent.vue
+++ b/src/components/ChangelogContent.vue
@@ -1,6 +1,18 @@
 <template>
   <q-timeline color="secondary">
     <q-timeline-entry
+      title="v2.4.3"
+      subtitle="Maintenance - 5/17/2026"
+      icon="build"
+      color="primary"
+    >
+      <div class="text-body2">
+        <ul>
+          <li>Fix Open5e monster import.</li>
+        </ul>
+      </div>
+    </q-timeline-entry>
+    <q-timeline-entry
       title="v2.4.2"
       subtitle="Minor Update - 3/01/2026"
       icon="build"

--- a/src/components/file/ImportButton.vue
+++ b/src/components/file/ImportButton.vue
@@ -83,7 +83,7 @@ import { Open5eMonster, Open5eMonsterResponse } from './Open5eData'
 
 const { t } = useI18n()
 
-const API_ROOT = 'https://api.open5e.com/monsters/'
+const API_ROOT = 'https://api.open5e.com/v1/monsters/'
 const monsterResults = ref<Open5eMonster[]>([])
 const selectedName = ref('')
 const next = ref<string | null>(null)


### PR DESCRIPTION
open5e is updating to api v2. due to the complexity of the open5e importer for this app, we'll stay on v1 until I have time to verify that the importer works with v2 data structures